### PR TITLE
Set EUMM in configure require to version shipped with 5.20.0 

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ my %args = (
   VERSION_FROM       => 'lib/Alien/pkgconf.pm',
 
   CONFIGURE_REQUIRES => {
-    'ExtUtils::MakeMaker' => 0,
+    'ExtUtils::MakeMaker' => '6.98',
     'JSON::PP'            => '2.27400',
   },
   TEST_REQUIRES      => {


### PR DESCRIPTION
Because it seems to not upgrade build requires with version shipped in 5.18.4 and 5.16.3. With this commit I fix cpan tester (that do not reported this, but can be impacted) but not CI (that is impacted but require additional changes like META.* files in the directory and for instance a dzil setup)

I can also add META.* files but I feel like this is not what you want (except if they are produced from dzil)

Version of EUMM taken from https://perldoc.perl.org/perl5200delta.html

Linked to #6 and https://github.com/plicease/cip/pull/13