### PR TITLE
disable the use of 1.9.x or better for now

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,10 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         cip:
-          - tag: "5.35"
+          - tag: "5.37"
+          - tag: "5.36"
+          - tag: "5.36-alpine3.16"
+          - tag: "5.36-fedora36"
           - tag: "5.34"
-          - tag: "5.34-alpine3.11"
-          - tag: "5.34-fedora34"
           - tag: "5.32"
           - tag: "5.30"
           - tag: "5.28"

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Alien-pkgconf
 
+  - Removing pkgconf 1.9.x for now, as it contains breaking
+    ABI changes that are not easy to reconsile for PkgConfig::LibPkgConf
+    Hopefully we can revisit support for 2.x when/if it becomes stable.
+
 0.17 2020-05-19 03:48:15 -0600
   - Add detection logic for Alpine Linux (tib++ gh#5)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,10 +1,8 @@
-.travis.yml
 Changes
 INSTALL
 lib/Alien/pkgconf.pm
 LICENSE
 maint/releaseprep
-maint/travis
 Makefile.PL
 MANIFEST			This list of files
 patch/pkgconf-cygwin-1.2.1.diff

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -84,7 +84,7 @@ eval {
   die "ALIEN_INSTALL_TYPE" if defined $ENV{ALIEN_INSTALL_TYPE}
                            && $ENV{ALIEN_INSTALL_TYPE} eq 'share';
 
-  system 'pkgconf', '--atleast-version=1.5.2', 'libpkgconf';
+  system 'pkgconf', '--atleast-version=1.5.2', '--max-version=1.8.0', 'libpkgconf';
   die "no pkgconf" if $?;
   my $cflags = `pkgconf --cflags libpkgconf`;
   die "getting cflags" if $?;

--- a/script/fetch.pl
+++ b/script/fetch.pl
@@ -94,6 +94,8 @@ $url = do {
     my @version = split /\./, $2;
     push @version, 0, 0 if @version == 1;
     push @version, 0    if @version == 2;
+    next if $version[0] >= 2;
+    next if $version[0] == 1 && $version[1] >= 9;
     push @list, [ $path, \@version ];
   }
 

--- a/t/xs.t
+++ b/t/xs.t
@@ -12,6 +12,12 @@ my $xs = do { local $/; <DATA> };
 xs_ok $xs, with_subtest {
   ok( Foo::pkgconf_compare_version("1.2.3","1.2.3") == 0 );
   ok( Foo::pkgconf_compare_version("1.2.3","1.2.4") != 0 );
+
+  cmp_ok( Foo::pkgconf_version(), ">", 10502, "pkgconf is at least 1.5.2" );
+  note "version = @{[ Foo::pkgconf_version() ]}";
+
+  # For now 1.9.x is unfortunately not supported 
+  cmp_ok( Foo::pkgconf_version(), "<", 10900, "pkgconf is not 1.9.x or 2.x" );
 };
 
 done_testing;
@@ -28,3 +34,10 @@ int
 pkgconf_compare_version(a,b)
     const char *a;
     const char *b;
+
+int
+pkgconf_version()
+  CODE:
+    RETVAL = LIBPKGCONF_VERSION;
+  OUTPUT:
+    RETVAL


### PR DESCRIPTION
pkgconf 1.9.x is testing for an eventual 2.x release that includes breaking changes.

This was uncovered in CI for https://github.com/PerlAlien/Alien-Build/pull/317