### PR TITLE
Sort JSON entries

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -100,7 +100,7 @@ eval {
   my $status_filename = File::Spec->catfile('_alien', '05stage.json');
   mkdir '_alien' unless -d '_alien';
   open my $fh, '>', $status_filename;
-  print $fh JSON::PP::encode_json({
+  print $fh JSON::PP->new->utf8->canonical->encode({
     cflags       => $cflags,
     libs         => $libs,
     install_type => 'system',

--- a/script/build.pl
+++ b/script/build.pl
@@ -148,5 +148,5 @@ chdir(_catdir(File::Spec->updir, File::Spec->updir, File::Spec->updir));
 
 my $fh;
 open($fh, '>', $status_filename) || die "unable to write $status_filename $!";
-print $fh encode_json({ destdir => $ENV{DESTDIR}, prefix => \@prefix, skip => 0 });
+print $fh JSON::PP->new->utf8->canonical->encode({ destdir => $ENV{DESTDIR}, prefix => \@prefix, skip => 0 });
 close $fh;

--- a/script/probe.pl
+++ b/script/probe.pl
@@ -329,5 +329,5 @@ unshift @{ $status{pkg_config_dir} }, $my_pkg_config_dir;
 
 mkdir '_alien' unless -d '_alien';
 open my $fh, '>', $status_filename;
-print $fh encode_json(\%status);
+print $fh JSON::PP->new->utf8->canonical->encode(\%status);
 close $fh;

--- a/script/stage.pl
+++ b/script/stage.pl
@@ -71,13 +71,13 @@ foreach my $type (qw( dll static ))
 {
   my $filename = File::Spec->catfile($share_dir, 'status.json');
   open my $fh, '>', $filename;
-  print $fh encode_json(\%status);
+  print $fh JSON::PP->new->utf8->canonical->encode(\%status);
   close $fh;
 }
 
 {
   open my $fh, '>', $status_filename;
-  print $fh encode_json(\%status);
+  print $fh JSON::PP->new->utf8->canonical->encode(\%status);
   close $fh;
 }
 


### PR DESCRIPTION
JSON::PP does not sort elements of JSON. That makes installed status.json binary nondeterministic. To make builds reproducible, this patch sorts the JSON entries.